### PR TITLE
OS10機能の音声キャプチャについて

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="1.8" />
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="testRunner" value="PLATFORM" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">
@@ -12,7 +14,7 @@
           </set>
         </option>
         <option name="resolveModulePerSourceSet" value="false" />
-        <option name="testRunner" value="PLATFORM" />
+        <option name="useQualifiedModuleNames" value="true" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="BintrayJCenter" />
+      <option name="name" value="BintrayJCenter" />
+      <option name="url" value="https://jcenter.bintray.com/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="Google" />
+      <option name="name" value="Google" />
+      <option name="url" value="https://dl.google.com/dl/android/maven2/" />
+    </remote-repository>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -49,7 +49,7 @@
       </profile-state>
     </entry>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <!--
+        Android10で[android.media.projection.MediaProjection]は、
+        foregroundServiceType、mediaProjectionの指定がされたフォアグランドサービスで扱う必要がある。
+        例えば、ActivityとかでMediaProjectionの初期化処理すると、SecurityExceptionが発生する.
+        -->
         <service
             android:name=".AudioCaptureService"
             android:foregroundServiceType="mediaProjection" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,11 +19,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <!--
-        Android10で[android.media.projection.MediaProjection]は、
-        foregroundServiceType、mediaProjectionの指定がされたフォアグランドサービスで扱う必要がある。
-        例えば、ActivityとかでMediaProjectionの初期化処理すると、SecurityExceptionが発生する.
-        -->
+        <!-- -->
         <service
             android:name=".AudioCaptureService"
             android:foregroundServiceType="mediaProjection" />

--- a/app/src/main/java/com/zynger/audiocapturesample/MainActivity.kt
+++ b/app/src/main/java/com/zynger/audiocapturesample/MainActivity.kt
@@ -60,6 +60,9 @@ class MainActivity : AppCompatActivity() {
         ) == PackageManager.PERMISSION_GRANTED
     }
 
+    /**
+     * オーディオキャプチャするには、RECORD_AUDIOパーミッションの付与が必要。
+     */
     private fun requestRecordAudioPermission() {
         ActivityCompat.requestPermissions(
             this,

--- a/app/src/main/java/com/zynger/audiocapturesample/MainActivity.kt
+++ b/app/src/main/java/com/zynger/audiocapturesample/MainActivity.kt
@@ -60,13 +60,10 @@ class MainActivity : AppCompatActivity() {
         ) == PackageManager.PERMISSION_GRANTED
     }
 
-    /**
-     * オーディオキャプチャするには、RECORD_AUDIOパーミッションの付与が必要。
-     */
     private fun requestRecordAudioPermission() {
         ActivityCompat.requestPermissions(
             this,
-            arrayOf(Manifest.permission.RECORD_AUDIO),
+            arrayOf(Manifest.permission.RECORD_AUDIO), //
             RECORD_AUDIO_PERMISSION_REQUEST_CODE
         )
     }


### PR DESCRIPTION
[AudioPlaybackCapture API](https://developer.android.com/reference/android/media/AudioPlaybackCaptureConfiguration.Builder) は、Android 10から追加された。
端末内の内部音声をユーザの許可を求めた上で、フォアグランドサービスにより、録音することが可能。


[ブログ記事](https://developers-jp.googleblog.com/2019/07/capturing-audio-in-android-q.html)
[機能](https://developer.android.com/guide/topics/media/playback-capture)

## 動作確認方法

サンプルでは、PCMファイルを吐き出すので[Audacity](https://www.audacityteam.org/download/)というツールを使って動作確認した。

<img width="956" alt="スクリーンショット 2021-03-23 19 39 43" src="https://user-images.githubusercontent.com/16476224/112133909-86dd9a00-8c0f-11eb-9c84-f5002fef26ff.png">

<img width="948" alt="スクリーンショット 2021-03-23 19 40 08" src="https://user-images.githubusercontent.com/16476224/112133961-952bb600-8c0f-11eb-92a7-2d7682c1c70b.png">

<img width="941" alt="スクリーンショット 2021-03-23 19 39 19" src="https://user-images.githubusercontent.com/16476224/112133858-775e5100-8c0f-11eb-9935-b947f558ac26.png">
